### PR TITLE
Default to using the maximum number of available cores for test execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ In order to run tests in parallel, you have to do the following:
 
 * Compile (or, more precisely, *link*) your test program with the `-threaded`
   flag;
-* Launch the program with `-j 4 +RTS -N4 -RTS` (to use 4 threads).
+* Launch the program with `+RTS -N -RTS`.
 
 ### Timeout
 

--- a/core/Test/Tasty/Options/Core.hs
+++ b/core/Test/Tasty/Options/Core.hs
@@ -15,6 +15,7 @@ import Data.Proxy
 import Data.Tagged
 import Data.Fixed
 import Options.Applicative
+import GHC.Conc
 
 import Test.Tasty.Options
 import Test.Tasty.Patterns
@@ -29,7 +30,7 @@ import Test.Tasty.Patterns
 newtype NumThreads = NumThreads { getNumThreads :: Int }
   deriving (Eq, Ord, Num, Typeable)
 instance IsOption NumThreads where
-  defaultValue = 1
+  defaultValue = NumThreads numCapabilities
   parseValue = mfilter onlyPositive . fmap NumThreads . safeRead
   optionName = return "num-threads"
   optionHelp = return "Number of threads to use for tests execution"


### PR DESCRIPTION
This is particularly useful because it allows multithreading to be enabled by default in a project's Cabal file without having to guess the number of available CPU cores.