### PR TITLE
Fix # 101 Buffer output to avoid slowdowns when printing test results

### DIFF
--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -68,9 +68,10 @@ produceOutput opts tree =
       level <- ask
 
       let
-        printTestName =
+        printTestName = do
           printf "%s%s: %s" (indent level) name
             (replicate (alignment - indentSize * level - length name) ' ')
+          hFlush stdout
 
         printTestResult result = do
           rDesc <- formatMessage $ resultDescription result
@@ -293,7 +294,7 @@ consoleTestReporter =
     then (do hideCursor; k) `finally` showCursor
     else k) $ do
 
-      hSetBuffering stdout NoBuffering
+      hSetBuffering stdout LineBuffering
 
       let
         whenColor = lookupOption opts


### PR DESCRIPTION
Fix #101 Windows slowdown issue caused by unbuffered output.