### PR TITLE
Explicitly request sudo on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 env:
  - GHCVER=7.4.2
  - GHCVER=7.6.3


### PR DESCRIPTION
This is probably not a problem for your own repository at the moment, but the travis build will not work
for newly forked repositories. This is because Travis tries to use the new containerized builds because there is no "sudo" command in the actual .travis.yml file. This fails: https://travis-ci.org/phile314/tasty/jobs/58186359

At the moment, Travis only tries to use the containerized builds for recently created repositories, but this will probably apply to all (including your own) repositories in due time. See also http://blog.travis-ci.com/2015-03-31-docker-default-on-the-way/ .

If sudo access is explicitly requested, it works fine:
https://travis-ci.org/phile314/tasty/jobs/58186575