### PR TITLE
Enable FlexibleContexts in ConsoleReporter

### DIFF
--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -1,5 +1,5 @@
 -- vim:fdm=marker:foldtext=foldtext()
-{-# LANGUAGE BangPatterns, ImplicitParams, MultiParamTypeClasses, DeriveDataTypeable #-}
+{-# LANGUAGE BangPatterns, ImplicitParams, MultiParamTypeClasses, DeriveDataTypeable, FlexibleContexts #-}
 -- | Console reporter ingredient
 module Test.Tasty.Ingredients.ConsoleReporter
   ( consoleTestReporter


### PR DESCRIPTION
In ghc-HEAD (2015-05-06), GHC says the following as part of an error message:

```
Test/Tasty/Ingredients/ConsoleReporter.hs:124:11: error:
    Could not deduce (MonadState IntMap.Key f)
      arising from a use of ‘get’
    from the context: (?colors::Bool, Monoid b)
      bound by the type signature for:
               foldTestOutput :: (?colors::Bool, Monoid b) =>
                                 (IO () -> IO Result -> (Result -> IO ()) -> b)
                                 -> (IO () -> b -> b) -> TestOutput -> StatusMap -> b
      at Test/Tasty/Ingredients/ConsoleReporter.hs:(117,6)-(120,33)
    or from: Monad f
      bound by the inferred type of go :: Monad f => TestOutput -> Ap f b
      at Test/Tasty/Ingredients/ConsoleReporter.hs:(123,3)-(135,18)
```

This is due to the fact that GHC, as of 7.10, will no longer infer types that need _unspecified_ LANGUAGE pragma's. 
The problem is, that `go` should actually get the inferred type:

```haskell
go :: MonadState IntMap.Key f => TestOutput -> Ap f b
```

But that type needs FlexibleContexts, hence we need to add it.

Note that tasty compiles on GHC 7.10.1, but the behaviour we see in HEAD might be ported over to 7.10.2, so this commit will future-proof tasty for such an event.