### PR TITLE
Update continuous integration with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,46 @@
-sudo: required
+# Use the container-based infrastructure
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.cabal
+
+addons:
+  apt:
+    sources:
+      - hvr-ghc
+    packages:
+      - cabal-install-1.18
+      - cabal-install-1.22
+      - cabal-install-head
+      - ghc-7.4.2
+      - ghc-7.6.3
+      - ghc-7.8.4
+      - ghc-7.10.2
+      - ghc-head
+
+# See also https://github.com/hvr/multi-ghc-travis for more information
 env:
- - GHCVER=7.4.2
- - GHCVER=7.6.3
- - GHCVER=7.8.3
-install: /bin/true
-script: ./ci-test
+ # we have to use CABALVER=1.18 for GHC<7.8 as well, as
+ # Travis' configuration isn't compatible with cabal-install-1.16
+ - GHCVER=7.4.2 CABALVER=1.18
+ - GHCVER=7.6.3 CABALVER=1.18
+ - GHCVER=7.8.4 CABALVER=1.18
+ - GHCVER=7.10.2 CABALVER=1.22
+ - GHCVER=head CABALVER=head
+
+matrix:
+  allow_failures:
+   - env: GHCVER=head CABALVER=head
+
+# Note: the distinction between `before_install` and `install` is not
+#       important.
+before_install:
+ - export PATH=$HOME/.cabal/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+ - cabal --version
+
+install:
+ - travis_retry cabal update
+
+script:
+ - ./ci-test

--- a/ci-test
+++ b/ci-test
@@ -2,17 +2,10 @@
 
 set -e
 
-sudo add-apt-repository -y ppa:hvr/ghc
-sudo apt-get update
-sudo apt-get install cabal-install-1.18 ghc-$GHCVER happy
-export PATH=$HOME/.cabal/bin:/opt/ghc/$GHCVER/bin:$PATH
-
-cabal-1.18 update
-
 for i in core hunit quickcheck smallcheck core-tests
 do
   cd $i
-  cabal-1.18 install --enable-tests
+  cabal install --enable-tests --force-reinstalls
   cd ..
 done
 


### PR DESCRIPTION
- Use Travis' (supposedly quicker) container-based infrastructure
- Add GHC-7.10.2 and GHC-head to the build matrix
- Cache the .cabal and .ghc directories
