### PR TITLE
Clarify IsTest’s specification with regard to exceptions

### DIFF
--- a/core/Test/Tasty/Core.hs
+++ b/core/Test/Tasty/Core.hs
@@ -18,12 +18,14 @@ import Text.Printf
 -- | If a test failed, 'FailureReason' describes why
 data FailureReason
   = TestFailed
-    -- ^ test provider indicated failure
+    -- ^ test provider indicated failure of the code to test, either because
+    -- the tested code returned wrong results, or raised an exception
   | TestThrewException SomeException
-    -- ^ test resulted in an exception. Note that some test providers may
-    -- catch exceptions in order to provide more meaningful errors. In that
-    -- case, the 'FailureReason' will be 'TestFailed', not
-    -- 'TestThrewException'.
+    -- ^ the test code itself raised an exception. Typical cases include missing
+    -- example input or output files.
+    --
+    -- Usually, providers do not have to implement this, as their 'run' method
+    -- may simply raise an exception.
   | TestTimedOut Integer
     -- ^ test didn't complete in allotted time
   deriving Show
@@ -95,6 +97,12 @@ data Progress = Progress
 -- the provider.
 class Typeable t => IsTest t where
   -- | Run the test
+  --
+  -- This method should cleanly catch any exceptions in the code to test, and
+  -- return them as part of the 'Result', see 'FailureReason' for an
+  -- explanation. It is ok for 'run' to raise an exception if there is a
+  -- problem with the test suite code itself (for example, if a file that
+  -- should contain example data or expected output is not found).
   run
     :: OptionSet -- ^ options
     -> t -- ^ the test to run

--- a/quickcheck/Test/Tasty/QuickCheck.hs
+++ b/quickcheck/Test/Tasty/QuickCheck.hs
@@ -144,6 +144,8 @@ instance IsTest QC where
       testRunner = if verbose
                      then QC.verboseCheckWithResult
                      else QC.quickCheckWithResult
+
+    -- Quickcheck already catches exceptions, no need to do it here.
     r <- testRunner args prop
 
     qcOutput <- formatMessage $ QC.output r


### PR DESCRIPTION
as discussed in #125, and update test runners:
 HUnit: Was already catching exceptions.
 QuickCheck: QuickCheck catches exceptions on its own.
 SmallCheck: Exception catching added.