### PR TITLE
Add optparse-applicative <0.13 upper bound.

### DIFF
--- a/core/tasty.cabal
+++ b/core/tasty.cabal
@@ -54,7 +54,7 @@ library
     mtl,
     tagged >= 0.5,
     regex-tdfa >= 1.1.8.2,
-    optparse-applicative >= 0.11,
+    optparse-applicative >= 0.11 && <0.13,
     deepseq >= 1.3,
     unbounded-delays >= 0.1,
     async >= 2.0,


### PR DESCRIPTION
Fixes https://github.com/feuerbach/tasty/issues/145