### PR TITLE
Build with GHCJS

### DIFF
--- a/core/tasty.cabal
+++ b/core/tasty.cabal
@@ -58,8 +58,12 @@ library
     deepseq >= 1.3,
     unbounded-delays >= 0.1,
     async >= 2.0,
-    ansi-terminal >= 0.6.2,
-    clock >= 0.4.4.0
+    ansi-terminal >= 0.6.2
+
+  if !impl(ghcjs)
+    build-depends: clock >= 0.4.4.0
+  else
+    build-depends: time >= 1.4
 
   if impl(ghc < 7.6)
     -- for GHC.Generics


### PR DESCRIPTION
The `clock` package is not supported by GHCJS. This patch falls back to using the system time, which is supported, in a GHCJS build (other platforms keep using `clock`).

This somewhat reverts 6f755209109afa2759e48ca01e8162fcb23ebd69.

Tested with the following `stack.yaml`::

```
packages:
- core/

resolver: lts-6.20
compiler: ghcjs-0.2.0.9006020_ghc-7.10.3
compiler-check: match-exact

setup-info:
  ghcjs:
    source:
      ghcjs-0.2.0.9006020_ghc-7.10.3:
         url: http://ghcjs.tolysz.org/lts-6.20-9006020.tar.gz
         sha1: a6cea90cd8121eee3afb201183c6e9bd6bacd94a
```

See: 6f755209109afa2759e48ca01e8162fcb23ebd69
See: https://github.com/feuerbach/tasty/issues/98
See: https://github.com/feuerbach/tasty/pull/118
