### PR TITLE
passing down extra parent names to single test runner

### DIFF
--- a/core-tests/test.hs
+++ b/core-tests/test.hs
@@ -53,7 +53,7 @@ getTestNames :: OptionSet -> TestTree -> [String]
 getTestNames =
   foldTestTree
     trivialFold
-      { foldSingle = \_ name _ -> [name]
+      { foldSingle = \_ name _ _ -> [name]
       , foldGroup = \n l -> map ((n ++ ".") ++) l
       }
 

--- a/core/Test/Tasty/Core.hs
+++ b/core/Test/Tasty/Core.hs
@@ -172,7 +172,7 @@ testGroup = TestGroup
 -- instead. This way your code won't break when new nodes/fields are
 -- indroduced.
 data TreeFold b = TreeFold
-  { foldSingle :: forall t . IsTest t => OptionSet -> TestName -> t -> b
+  { foldSingle :: forall t . IsTest t => OptionSet -> TestName -> [TestName] -> t -> b
   , foldGroup :: TestName -> b -> b
   , foldResource :: forall a . ResourceSpec a -> (IO a -> b) -> b
   }
@@ -230,7 +230,7 @@ foldTestTree (TreeFold fTest fGroup fResource) opts tree =
       case tree of
         SingleTest name test
           | testPatternMatches pat (path ++ [name])
-            -> fTest opts name test
+            -> fTest opts name path test
           | otherwise -> mempty
         TestGroup name trees ->
           fGroup name $ foldMap (go pat (path ++ [name]) opts) trees
@@ -246,7 +246,7 @@ treeOptions =
   Map.elems .
 
   foldTestTree
-    trivialFold { foldSingle = \_ _ -> getTestOptions }
+    trivialFold { foldSingle = \_ _ _ -> getTestOptions }
     mempty
 
   where

--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -63,8 +63,8 @@ produceOutput opts tree =
 
     runSingleTest
       :: (IsTest t, ?colors :: Bool)
-      => OptionSet -> TestName -> t -> Ap (Reader Level) TestOutput
-    runSingleTest _opts name _test = Ap $ do
+      => OptionSet -> TestName -> [TestName] -> t -> Ap (Reader Level) TestOutput
+    runSingleTest _opts name _ _test = Ap $ do
       level <- ask
 
       let
@@ -451,7 +451,7 @@ computeAlignment opts =
   fromMonoid .
   foldTestTree
     trivialFold
-      { foldSingle = \_ name _ level -> Maximum (length name + level)
+      { foldSingle = \_ name _ _ level -> Maximum (length name + level)
       , foldGroup = \_ m -> m . (+ indentSize)
       }
     opts

--- a/core/Test/Tasty/Ingredients/ListTests.hs
+++ b/core/Test/Tasty/Ingredients/ListTests.hs
@@ -29,7 +29,7 @@ testsNames :: OptionSet -> TestTree -> [TestName]
 testsNames {- opts -} {- tree -} =
   foldTestTree
     trivialFold
-      { foldSingle = \_opts name _test -> [name]
+      { foldSingle = \_opts name _ _test -> [name]
       , foldGroup = \groupName names -> map ((groupName ++ "/") ++) names
       }
 

--- a/core/Test/Tasty/Run.hs
+++ b/core/Test/Tasty/Run.hs
@@ -211,7 +211,7 @@ createTestActions opts tree = do
   return (tests', rvars)
 
   where
-    runSingleTest opts _ test = Traversal $ do
+    runSingleTest opts _ _ test = Traversal $ do
       statusVar <- liftIO $ atomically $ newTVar NotStarted
       let
         act (inits, fins) =


### PR DESCRIPTION
## What changed?
- the single test runner `TreeFold.foldSingle` takes extra parameter `[TestName]` for its parent test names.

## Why?
- for `tasty-ant-xml`
- when creating an xml test result, we need specify `classname` of each test case, which mean [Full class name for the class the test method is in](https://github.com/haishengwu-okta/JUnit-Schema/blob/master/JUnit.xsd#L122-L126)
- code changes for `tasty-ant-xml`: https://github.com/haishengwu-okta/tasty-ant-xml/pull/1/files#diff-919c7cdd8a5d4c23e1e7642fa90c014f
- @ocharles 


Thanks.
