### PR TITLE
Introduce optionCLParser' and use it instead of option

### DIFF
--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -357,15 +357,6 @@ instance IsOption UseColor where
   parseValue = parseUseColor
   optionName = return "color"
   optionHelp = return "When to use colored output. Options are 'never', 'always' and 'auto' (default: 'auto')"
-  optionCLParser =
-    option parse
-      (  long name
-      <> help (untag (optionHelp :: Tagged UseColor String))
-      )
-    where
-      name = untag (optionName :: Tagged UseColor String)
-      parse = str >>=
-        maybe (readerError $ "Could not parse " ++ name) pure <$> parseValue
 
 -- | @useColor when isTerm@ decides if colors should be used,
 --   where @isTerm@ denotes where @stdout@ is a terminal device.

--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -334,7 +334,7 @@ instance IsOption Quiet where
   parseValue = fmap Quiet . safeRead
   optionName = return "quiet"
   optionHelp = return "Do not produce any output; indicate success only by the exit code"
-  optionCLParser = flagCLParser (Just 'q') (Quiet True)
+  optionCLParser = mkFlagCLParser (short 'q') (Quiet True)
 
 -- | Report only failed tests
 newtype HideSuccesses = HideSuccesses Bool
@@ -344,7 +344,7 @@ instance IsOption HideSuccesses where
   parseValue = fmap HideSuccesses . safeRead
   optionName = return "hide-successes"
   optionHelp = return "Do not print tests that passed successfully"
-  optionCLParser = flagCLParser Nothing (HideSuccesses True)
+  optionCLParser = mkFlagCLParser mempty (HideSuccesses True)
 
 -- | When to use color on the output
 data UseColor

--- a/core/Test/Tasty/Ingredients/ListTests.hs
+++ b/core/Test/Tasty/Ingredients/ListTests.hs
@@ -8,6 +8,8 @@ module Test.Tasty.Ingredients.ListTests
 
 import Data.Typeable
 import Data.Proxy
+import Data.Monoid
+import Options.Applicative
 
 import Test.Tasty.Core
 import Test.Tasty.Options
@@ -22,7 +24,7 @@ instance IsOption ListTests where
   parseValue = fmap ListTests . safeRead
   optionName = return "list-tests"
   optionHelp = return "Do not run the tests; just print their names"
-  optionCLParser = flagCLParser (Just 'l') (ListTests True)
+  optionCLParser = mkFlagCLParser (short 'l') (ListTests True)
 
 -- | Obtain the list of all tests in the suite
 testsNames :: OptionSet -> TestTree -> [TestName]

--- a/core/Test/Tasty/Options.hs
+++ b/core/Test/Tasty/Options.hs
@@ -17,6 +17,7 @@ module Test.Tasty.Options
   , OptionDescription(..)
     -- * Utilities
   , flagCLParser
+  , mkFlagCLParser
   , mkOptionCLParser
   , safeRead
   ) where
@@ -48,7 +49,8 @@ class Typeable v => IsOption v where
   --
   -- It has a default implementation in terms of the other methods.
   -- You may want to override it in some cases (e.g. add a short flag) and
-  -- 'flagCLParser', 'mkOptionCLParser' might come in handy.
+  -- 'flagCLParser', 'mkFlagCLParser' and 'mkOptionCLParser' might come in
+  -- handy.
   --
   -- Even if you override this, you still should implement all the methods
   -- above, to allow alternative interfaces.
@@ -112,10 +114,18 @@ flagCLParser
   => Maybe Char -- ^ optional short flag
   -> v          -- ^ non-default value (when the flag is supplied)
   -> Parser v
-flagCLParser mbShort v = flag' v
-  (  foldMap short mbShort
-  <> long (untag (optionName :: Tagged v String))
+flagCLParser mbShort = mkFlagCLParser (foldMap short mbShort)
+
+-- | Command-line flag parser that takes additional option modifiers.
+mkFlagCLParser
+  :: forall v . IsOption v
+  => Mod FlagFields v -- ^ option modifier
+  -> v                -- ^ non-default value (when the flag is supplied)
+  -> Parser v
+mkFlagCLParser mod v = flag' v
+  (  long (untag (optionName :: Tagged v String))
   <> help (untag (optionHelp :: Tagged v String))
+  <> mod
   )
 
 -- | Command-line option parser that takes additional option modifiers.

--- a/core/Test/Tasty/Options/Core.hs
+++ b/core/Test/Tasty/Options/Core.hs
@@ -35,16 +35,7 @@ instance IsOption NumThreads where
   parseValue = mfilter onlyPositive . fmap NumThreads . safeRead
   optionName = return "num-threads"
   optionHelp = return "Number of threads to use for tests execution"
-  optionCLParser =
-    option parse
-      (  short 'j'
-      <> long name
-      <> help (untag (optionHelp :: Tagged NumThreads String))
-      )
-    where
-      name = untag (optionName :: Tagged NumThreads String)
-      parse = str >>=
-        maybe (readerError $ "Could not parse " ++ name) pure <$> parseValue
+  optionCLParser = mkOptionCLParser (short 'j')
 
 -- | Filtering function to prevent non-positive number of threads
 onlyPositive :: NumThreads -> Bool
@@ -67,16 +58,7 @@ instance IsOption Timeout where
       <*> pure str
   optionName = return "timeout"
   optionHelp = return "Timeout for individual tests (suffixes: ms,s,m,h; default: s)"
-  optionCLParser =
-    option parse
-      (  short 't'
-      <> long name
-      <> help (untag (optionHelp :: Tagged Timeout String))
-      )
-    where
-      name = untag (optionName :: Tagged Timeout String)
-      parse = str >>=
-        maybe (readerError $ "Could not parse " ++ name) pure <$> parseValue
+  optionCLParser = mkOptionCLParser (short 't')
 
 parseTimeout :: String -> Maybe Integer
 parseTimeout str =

--- a/core/Test/Tasty/Patterns.hs
+++ b/core/Test/Tasty/Patterns.hs
@@ -89,12 +89,7 @@ instance IsOption TestPattern where
   parseValue = Just . parseTestPattern
   optionName = return "pattern"
   optionHelp = return "Select only tests that match pattern"
-  optionCLParser =
-    option (fmap parseTestPattern str)
-      (  short 'p'
-      <> long (untag (optionName :: Tagged TestPattern String))
-      <> help (untag (optionHelp :: Tagged TestPattern String))
-      )
+  optionCLParser = mkOptionCLParser (short 'p')
 
 -- | Parse a pattern
 parseTestPattern :: String -> TestPattern

--- a/quickcheck/Test/Tasty/QuickCheck.hs
+++ b/quickcheck/Test/Tasty/QuickCheck.hs
@@ -38,6 +38,7 @@ import Test.QuickCheck hiding -- for re-export
 import Data.Typeable
 import Data.Proxy
 import Data.List
+import Data.Monoid
 import Text.Printf
 import Control.Applicative
 
@@ -120,7 +121,7 @@ instance IsOption QuickCheckVerbose where
   parseValue = fmap QuickCheckVerbose . safeRead
   optionName = return "quickcheck-verbose"
   optionHelp = return "Show the generated test cases"
-  optionCLParser = flagCLParser Nothing (QuickCheckVerbose True)
+  optionCLParser = mkFlagCLParser mempty (QuickCheckVerbose True)
 
 instance IsTest QC where
   testOptions = return


### PR DESCRIPTION
We had this function in our code but I feel it really belongs in the library
itself.