### PR TITLE
Bump tasty lower bound in tasty-quickcheck

### DIFF
--- a/quickcheck/tasty-quickcheck.cabal
+++ b/quickcheck/tasty-quickcheck.cabal
@@ -42,7 +42,7 @@ test-suite test
     test.hs
   build-depends:
       base >= 4 && < 5
-    , tasty >= 0.10
+    , tasty >= 0.11.1
     , tasty-quickcheck
     , tasty-hunit
     , pcre-light


### PR DESCRIPTION
`mkFlagCLParser` was added in `0.11.1`