### PR TITLE
Revise console output API.

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changes
 =======
 
+Version 0.12
+--------------
+
+Backward compat breaking revision of `Test.Tasty.Ingredients.ConsoleReporter`
+that exposes the name of tests/groups.
+
 Version 0.11.3
 --------------
 

--- a/core/tasty.cabal
+++ b/core/tasty.cabal
@@ -2,7 +2,7 @@
 --  see http://haskell.org/cabal/users-guide/
 
 name:                tasty
-version:             0.11.3
+version:             0.12
 synopsis:            Modern and extensible testing framework
 description:         Tasty is a modern testing framework for Haskell.
                      It lets you combine your unit tests, golden


### PR DESCRIPTION
Make it easier to access the name of a test/group for things like labelling.

Add a way to report statistics without timing.

Add missing export.

Add CHANGELOG entries.

Fixed version of #186