### PR TITLE
Relax mtl requirement

### DIFF
--- a/core/Test/Tasty/Patterns/Eval.hs
+++ b/core/Test/Tasty/Patterns/Eval.hs
@@ -3,7 +3,7 @@ module Test.Tasty.Patterns.Eval (eval, withFields, asB) where
 
 import Prelude hiding (Ordering(..))
 import Control.Monad.Reader
-import Control.Monad.Except
+import Control.Monad.Error.Class
 import qualified Data.Sequence as Seq
 import Data.Foldable
 import Data.List

--- a/core/tasty.cabal
+++ b/core/tasty.cabal
@@ -61,7 +61,7 @@ library
     base >= 4.5 && < 5,
     stm >= 2.3,
     containers,
-    mtl >= 2.2.1,
+    mtl >= 2.1.3.1,
     tagged >= 0.5,
     optparse-applicative >= 0.11,
     deepseq >= 1.3,

--- a/core/tasty.cabal
+++ b/core/tasty.cabal
@@ -63,7 +63,7 @@ library
     containers,
     mtl >= 2.1.3.1,
     tagged >= 0.5,
-    optparse-applicative >= 0.11,
+    optparse-applicative >= 0.14,
     deepseq >= 1.3,
     unbounded-delays >= 0.1,
     async >= 2.0,


### PR DESCRIPTION
This let `tasty` compile with bundled `transformers-0.3` with GHC-7.8.*.
That's important for packages using e.g. `doctest` in their (other)
test-suites, as then `transformers` cannot be re-installed.