### PR TITLE
Hidden Template Haskell QuickCheck functions.

### DIFF
--- a/quickcheck/Test/Tasty/QuickCheck.hs
+++ b/quickcheck/Test/Tasty/QuickCheck.hs
@@ -36,6 +36,13 @@ import Test.QuickCheck hiding -- for re-export
   , verboseCheckWithResult
   , verboseCheckResult
   , verbose
+  -- Template Haskell functions
+#if MIN_VERSION_QuickCheck(2,11,0)
+  , allProperties
+#endif
+  , forAllProperties
+  , quickCheckAll
+  , verboseCheckAll
   )
 
 import Data.Typeable


### PR DESCRIPTION
When I wrote [this](https://stackoverflow.com/questions/47953171/using-the-quickcheckall-function-in-tasty-quickcheck) question, I was confused because the Haddock documentation for `tasty-quickcheck` shows the `quickCheckAll` function (see, for example, https://hackage.haskell.org/package/tasty-quickcheck-0.9.1/docs/doc-index-Q.html).

This PR hides some Template Haskell QuickCheck functions so these functions don't show up in the Haddock documentation.