### PR TITLE
Build all packages from the top level with `cabal new-build all`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .cabal-sandbox
 cabal.sandbox.config
+cabal.project.local
+dist-newstyle
 core-tests/dist
 core/dist
 hunit/dist

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,7 @@
+packages:
+  core
+  core-tests
+  hunit
+  quickcheck
+  smallcheck
+


### PR DESCRIPTION
Add cabal.project file
This will allow a user to build all the packages from the top level with
`cabal new-build all` or test all with `cabal new-test all`

Add cabal new-build artifacts to gitignore