### PR TITLE
Removed unused extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.stack-work
 .cabal-sandbox
 cabal.sandbox.config
 cabal.project.local

--- a/core-tests/exit-status-test.hs
+++ b/core-tests/exit-status-test.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, BangPatterns #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 import Test.Tasty
 import Test.Tasty.Options
 import Test.Tasty.HUnit

--- a/core/Test/Tasty/Core.hs
+++ b/core/Test/Tasty/Core.hs
@@ -1,7 +1,8 @@
 -- | Core types and definitions
-{-# LANGUAGE GeneralizedNewtypeDeriving, FlexibleContexts,
-             ExistentialQuantification, RankNTypes, DeriveDataTypeable,
-             DeriveGeneric #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE RankNTypes #-}
 module Test.Tasty.Core where
 
 import Control.Exception

--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -1,5 +1,5 @@
 -- vim:fdm=marker:foldtext=foldtext()
-{-# LANGUAGE BangPatterns, ImplicitParams, MultiParamTypeClasses, DeriveDataTypeable, FlexibleContexts #-}
+{-# LANGUAGE BangPatterns, ImplicitParams, FlexibleContexts #-}
 -- | Console reporter ingredient
 module Test.Tasty.Ingredients.ConsoleReporter
   ( consoleTestReporter

--- a/core/Test/Tasty/Ingredients/ListTests.hs
+++ b/core/Test/Tasty/Ingredients/ListTests.hs
@@ -1,5 +1,5 @@
 -- | Ingredient for listing test names
-{-# LANGUAGE CPP, GeneralizedNewtypeDeriving, DeriveDataTypeable #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 module Test.Tasty.Ingredients.ListTests
   ( ListTests(..)
   , testsNames

--- a/core/Test/Tasty/Options.hs
+++ b/core/Test/Tasty/Options.hs
@@ -1,7 +1,6 @@
-{-# LANGUAGE ScopedTypeVariables, DeriveDataTypeable,
-             ExistentialQuantification, GADTs,
-             FlexibleInstances, UndecidableInstances,
-             TypeOperators #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE UndecidableInstances #-}
 -- | Extensible options. They are used for provider-specific settings,
 -- ingredient-specific settings and core settings (such as the test name pattern).
 module Test.Tasty.Options

--- a/core/Test/Tasty/Options/Core.hs
+++ b/core/Test/Tasty/Options/Core.hs
@@ -1,5 +1,6 @@
 -- | Core options, i.e. the options used by tasty itself
-{-# LANGUAGE CPP, DeriveDataTypeable, GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# OPTIONS_GHC -fno-warn-type-defaults #-} -- for (^)
 module Test.Tasty.Options.Core
   ( NumThreads(..)

--- a/core/Test/Tasty/Patterns.hs
+++ b/core/Test/Tasty/Patterns.hs
@@ -1,6 +1,6 @@
 -- | Test patterns
 
-{-# LANGUAGE CPP, DeriveDataTypeable #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 
 module Test.Tasty.Patterns
   ( TestPattern

--- a/hunit/Test/Tasty/HUnit.hs
+++ b/hunit/Test/Tasty/HUnit.hs
@@ -15,7 +15,8 @@
 -- >    -- assertion no. 3 (would have failed, but won't be executed because
 -- >    -- the previous assertion has already failed)
 -- >    "foo" @?= "bar"
-{-# LANGUAGE TypeFamilies, DeriveDataTypeable #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE MonoLocalBinds #-}
 module Test.Tasty.HUnit
   (
     -- * Constructing test cases

--- a/hunit/Test/Tasty/HUnit/Orig.hs
+++ b/hunit/Test/Tasty/HUnit/Orig.hs
@@ -1,7 +1,5 @@
-{-# LANGUAGE DeriveDataTypeable, FlexibleInstances, TypeSynonymInstances #-}
-
--- required for HasCallStack by different versions of GHC
-{-# LANGUAGE ConstraintKinds, FlexibleContexts #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE FlexibleInstances #-}
 
 -- | This is the code copied from the original hunit package (v. 1.2.5.2).
 -- with minor modifications
@@ -214,4 +212,3 @@ instance Assertable String
 --
 -- 5. Assert that the conditions evaluated in step 2 are met.
 type AssertionPredicate = IO Bool
-

--- a/smallcheck/Test/Tasty/SmallCheck.hs
+++ b/smallcheck/Test/Tasty/SmallCheck.hs
@@ -1,7 +1,9 @@
 -- | This module allows to use SmallCheck properties in tasty.
-{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, FlexibleContexts,
-             TypeOperators, DeriveDataTypeable, TypeFamilies,
-             GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MonoLocalBinds #-}
 module Test.Tasty.SmallCheck
   ( testProperty
   , SmallCheckDepth(..)


### PR DESCRIPTION
Removed most unused extensions from every module. This has been done using the OrganizeExtensions refactoring of the Haskell-Tools framework. See http://www.haskelltools.org/