### PR TITLE
The field separator is . not /

### DIFF
--- a/core/Test/Tasty/Ingredients/ListTests.hs
+++ b/core/Test/Tasty/Ingredients/ListTests.hs
@@ -31,7 +31,7 @@ testsNames {- opts -} {- tree -} =
   foldTestTree
     trivialFold
       { foldSingle = \_opts name _test -> [name]
-      , foldGroup = \groupName names -> map ((groupName ++ "/") ++) names
+      , foldGroup = \groupName names -> map ((groupName ++ ".") ++) names
       }
 
 -- | The ingredient that provides the test listing functionality


### PR DESCRIPTION
`-l` still lists the test names using a / as the field separator.