### PR TITLE
Add LeanCheck provider on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ The following providers exist:
   property-based testing (based on [Hedgehog](http://hackage.haskell.org/package/hedgehog))
 * [tasty-hspec](http://hackage.haskell.org/package/tasty-hspec) — for
   [Hspec](http://hspec.github.io/) tests
+* [tasty-leancheck](http://hackage.haskell.org/package/tasty-leancheck) — for
+  enumerative property-based testing
+  (based on [LeanCheck](http://hackage.haskell.org/package/leancheck))
 * [tasty-program](http://hackage.haskell.org/package/tasty-program) — run
   external program and test whether it terminates successfully
 


### PR DESCRIPTION
I recently created a provider to use [LeanCheck](https://hackage.haskell.org/package/leancheck) with Tasty: [tasty-leancheck](https://hackage.haskell.org/package/tasty-leancheck).

This PR adds it to the list of providers.

Feel free to reject this if you don't intend to provide an exhaustive list.