### PR TITLE
GHCJS compatibility

### DIFF
--- a/core/tasty.cabal
+++ b/core/tasty.cabal
@@ -77,7 +77,7 @@ library
     -- for GHC.Generics
     build-depends: ghc-prim
 
-  if !os(windows)
+  if !os(windows) && !impl(ghcjs)
     build-depends: unix,
                    wcwidth
     cpp-options: -DUNIX


### PR DESCRIPTION
If package is build on linux `wcwidth` & `unix` packages are added
as dependencies. `wcwidth` calls C functions which makes it not
possible to run tests with GHCJS