### PR TITLE
color=always in Emacs

### DIFF
--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -398,6 +398,7 @@ consoleTestReporter =
 
       do
       isTerm <- hSupportsANSI stdout
+      isTermColor <- hSupportsANSIColor stdout
 
       (\k -> if isTerm
         then (do hideCursor; k) `finally` showCursor
@@ -406,7 +407,7 @@ consoleTestReporter =
           hSetBuffering stdout LineBuffering
 
           let
-            ?colors = useColor whenColor isTerm
+            ?colors = useColor whenColor isTermColor
 
           let
             toutput = buildTestOutput opts tree

--- a/core/tasty.cabal
+++ b/core/tasty.cabal
@@ -66,7 +66,7 @@ library
     optparse-applicative >= 0.14,
     unbounded-delays >= 0.1,
     async >= 2.0,
-    ansi-terminal >= 0.6.2
+    ansi-terminal >= 0.9
 
   if flag(clock)
     build-depends: clock >= 0.4.4.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,6 +7,7 @@ packages:
 - core-tests/
 extra-deps:
 - wcwidth-0.0.2
+- ansi-terminal-0.9
 # this is needed for travis, because call-stack is absent from the old snapshots
 - call-stack-0.1.0
 flags: {}


### PR DESCRIPTION
As of https://github.com/haskell/haskell-mode/pull/1608 (and https://github.com/haskell/haskell-mode/pull/1609) Emacs is able to handle colour output in tasty tests by default.

Before I progress with this PR, I wanted to check if it's something you'd be interested in accepting. It saves me having to add `--color=always` to every invocation.

It is relatively easy to detect that we are within Emacs, we just look for the envvar `INSIDE_EMACS`. The logic to match how this is done in the JVM world is at https://github.com/jline/jline2/pull/288 / https://github.com/jline/jline2/commit/5366158937c49b6e277345e3e543ba61b6fe33b4

TL;DR emacs supports ansi colours but not echo and navigation, when compared to other "smart" terminals.

The situation I'd be concerned about is when cabal runs multiple tasty jobs in a batch and puts their output into a file instead of the console. In such cases I don't think we want colour output... but we would have the same problem in other terminals also. Is there a way to detect that?

A user or project level `.tasty` containing some options would be another way to do this.