### PR TITLE
Catch all exceptions and time each step in `testCaseSteps`

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 1.2.2
+-------------
+
+Expose timed and getTime
+
 Version 1.2.1
 -------------
 

--- a/core/tasty.cabal
+++ b/core/tasty.cabal
@@ -2,7 +2,7 @@
 --  see http://haskell.org/cabal/users-guide/
 
 name:                tasty
-version:             1.2.1
+version:             1.2.2
 synopsis:            Modern and extensible testing framework
 description:         Tasty is a modern testing framework for Haskell.
                      It lets you combine your unit tests, golden

--- a/hunit/CHANGELOG.md
+++ b/hunit/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 0.10.0.2
+----------------
+
+Catch all exceptions and time each step in testCaseSteps
+
 Version 0.10.0.1
 ----------------
 

--- a/hunit/tasty-hunit.cabal
+++ b/hunit/tasty-hunit.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                tasty-hunit
-version:             0.10.0.1
+version:             0.10.0.2
 synopsis:            HUnit support for the Tasty test framework.
 description:         HUnit support for the Tasty test framework.
                      .
@@ -32,7 +32,7 @@ library
   other-modules:       Test.Tasty.HUnit.Orig
                        Test.Tasty.HUnit.Steps
   other-extensions:    TypeFamilies, DeriveDataTypeable
-  build-depends:       base ==4.*, tasty >= 0.8, call-stack
+  build-depends:       base ==4.*, tasty >= 1.2.2, call-stack
   -- hs-source-dirs:      
   default-language:    Haskell2010
   ghc-options: -Wall


### PR DESCRIPTION
Resolves: #240 

Resolves: #137

-------

I did it against the `hunit-0.10.0.1` tag, but nothing changed in this region in `master`.

`getTime` is duplicated between this and `Test.Tasty.Run.getTime`, but—given the fragmentation and different versions—I’m not sure if 3 lines aren’t worth it… I might however not understand how all this works together. =)

Just a quick patch to make steps nicer², it’s a very-very useful feature for longer-running non-trivial tests.