### PR TITLE
Wait for tests to release their resources after Ctrl-C

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -134,6 +134,7 @@ script:
       fi
       (cd core-tests && stack --no-terminal $ARGS exec tasty-core-tests -- +RTS -N2)
       stack --no-terminal $ARGS exec core-tests/exit-status-tests.sh
+      stack --no-terminal $ARGS exec core-tests/resource-release-test.sh
       ;;
     cabal)
       cabal install --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES

--- a/core-tests/core-tests.cabal
+++ b/core-tests/core-tests.cabal
@@ -33,3 +33,10 @@ executable exit-status-test
   default-language:    Haskell2010
   default-extensions:  CPP
   ghc-options:         -Wall -fno-warn-type-defaults -threaded -with-rtsopts=-N
+
+executable resource-release-test
+  main-is:             resource-release-test.hs
+  build-depends:       base <= 5, tasty, tasty-hunit
+  default-language:    Haskell2010
+  default-extensions:  CPP
+  ghc-options:         -Wall -fno-warn-type-defaults -threaded -with-rtsopts=-N

--- a/core-tests/resource-release-test.hs
+++ b/core-tests/resource-release-test.hs
@@ -1,0 +1,37 @@
+import Test.Tasty
+import Test.Tasty.HUnit
+import Control.Concurrent
+import Control.Exception
+import Control.Monad
+import System.Environment
+
+
+-- verbose versions of everything, to make it easier to debug from travis logs
+
+verbose :: String -> IO ()
+verbose msg = putStrLn ("resource-release-test.hs: " ++ msg)
+
+verboseSleep :: Int -> IO ()
+verboseSleep seconds = do
+  verbose ("sleep " ++ show seconds)
+  threadDelay (seconds * 1000000)
+
+verboseTouchFile :: FilePath -> IO ()
+verboseTouchFile filePath = do
+  verbose ("touch " ++ filePath)
+  writeFile filePath ""
+
+
+main :: IO ()
+main = do
+  dir:args <- getArgs
+  withArgs args $ do
+    defaultMain $ testCase "Test" $ do
+      let body = do
+            verboseTouchFile (dir ++ "/test-has-started")
+            forever $ verboseSleep 1  -- wait for resource-release-test.sh to kill us
+          releaseResources = do
+            verbose "resource-release-test.hs: releasing resources..."
+            verboseSleep 1  -- bug: the program terminates here, before the resources are released
+            verboseTouchFile (dir ++ "/resources-are-released")
+      body `finally` releaseResources

--- a/core-tests/resource-release-test.sh
+++ b/core-tests/resource-release-test.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -ux
+
+# This assumes that the compiled resource-release-test executable
+# is in the PATH
+
+# create a folder for the duration of the test, and make sure it starts empty
+DIR=`dirname $0`/resource-release-test-files
+rm -rf "$DIR"
+mkdir "$DIR"
+function finish {
+  rm -rf "$DIR"
+}
+trap finish EXIT
+
+# start resource-release-test and wait until it's ready
+resource-release-test "$DIR" &
+PID="$!"
+while [ ! -f "$DIR/test-has-started" ]; do sleep 1; done
+
+# kill resource-release-test and wait for it to release its resources.
+# setsid runs 'kill' in a new process group, otherwise the signal doesn't get
+# delivered.
+kill -s INT "$PID"
+wait "$PID"
+
+# check that the resources were correctly released
+[ -f "$DIR/resources-are-released" ] || exit 1

--- a/core-tests/resource-release-test.sh
+++ b/core-tests/resource-release-test.sh
@@ -6,10 +6,10 @@ set -ux
 # is in the PATH
 
 # create a folder for the duration of the test, and make sure it starts empty
-DIR=`dirname $0`/resource-release-test-files
+DIR="$(dirname "$0")/resource-release-test-files"
 rm -rf "$DIR"
 mkdir "$DIR"
-function finish {
+finish() {
   rm -rf "$DIR"
 }
 trap finish EXIT

--- a/core-tests/resource-release-test.sh
+++ b/core-tests/resource-release-test.sh
@@ -20,8 +20,6 @@ PID="$!"
 while [ ! -f "$DIR/test-has-started" ]; do sleep 1; done
 
 # kill resource-release-test and wait for it to release its resources.
-# setsid runs 'kill' in a new process group, otherwise the signal doesn't get
-# delivered.
 kill -s INT "$PID"
 wait "$PID"
 

--- a/core/Test/Tasty/Parallel.hs
+++ b/core/Test/Tasty/Parallel.hs
@@ -4,6 +4,7 @@ module Test.Tasty.Parallel (ActionStatus(..), Action(..), runInParallel) where
 
 import Control.Monad
 import Control.Concurrent
+import Control.Concurrent.Async
 import Control.Concurrent.STM
 import Foreign.StablePtr
 
@@ -52,9 +53,9 @@ runInParallel nthreads actions = do
 
   actionsVar <- atomically $ newTMVar actions
 
-  pids <- replicateM nthreads (forkIO $ work actionsVar)
+  pids <- replicateM nthreads (async $ work actionsVar)
 
-  return $ mapM_ killThread pids
+  return $ mapM_ cancel pids
 
 work :: TMVar [Action] -> IO ()
 work actionsVar = go


### PR DESCRIPTION
`tasty` already has `withResource` for acquiring a resource which is shared by multiple tests, but within a single test, `bracket` and `finally` should still work as expected, right? Well, they don't :(

In the following simple example, if I hit Ctrl-C between `sleeping...` and `slept`, `releasing...` gets printed, but then the program terminates immediately without printing `released`. If I remove the `defaultMain $ testCase "acquire, sleep, release."` part and hit Ctrl-C at the same point, I get the expected behaviour: `releasing...` gets printed, the program hangs for 2 seconds, and then prints `released`.

    import Test.Tasty
    import Test.Tasty.HUnit
    
    import Control.Concurrent
    import Control.Exception
    
    main :: IO ()
    main = defaultMain $ testCase "acquire, sleep, release." $ do
      finally (putStrLn "sleeping..." >> threadDelay 2000000 >> putStrLn "slept")
              (putStrLn "releasing..." >> threadDelay 2000000 >> putStrLn "released")

This PR includes a change which fixes the problem ~in this case, but even though I can see that the problem is fixed when I use Ctrl-C, I am having some difficulties writing a test case. I spent the day on this and I still couldn't figure it out, so I am submitting what I have so far as a PR in the hope that you can help me finish it.~