### PR TITLE
Expose computeStatistics from ConsoleReporter

### DIFF
--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -15,6 +15,7 @@ module Test.Tasty.Ingredients.ConsoleReporter
   , useColor
   -- ** Test failure statistics
   , Statistics(..)
+  , computeStatistics
   , printStatistics
   , printStatisticsNoTime
   -- ** Outputting results
@@ -287,6 +288,9 @@ instance Semigroup Statistics where
   (<>) = mappend
 #endif
 
+-- | @computeStatistics@ computes a summary 'Statistics' for
+-- a given state of the 'StatusMap'.
+-- Useful in combination with @printStatistics@
 computeStatistics :: StatusMap -> IO Statistics
 computeStatistics = getApp . foldMap (\var -> Ap $
   (\r -> Statistics 1 (if resultSuccessful r then 0 else 1))


### PR DESCRIPTION
Closes #251 

Adds `computeStatistics` to the export list of the module.