### PR TITLE
Add .stack-work to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ core/dist
 hunit/dist
 quickcheck/dist
 smallcheck/dist
+.stack-work


### PR DESCRIPTION
`stack build` used to create a lot of folders:

```
.stack-work/
core-tests/.stack-work/
core/.stack-work/
hunit/.stack-work/
patch
quickcheck/.stack-work/
smallcheck/.stack-work/
```

Ignore all of them.