### PR TITLE
Add optional provider controlled detailed result reports

### DIFF
--- a/core/Test/Tasty/ConsoleFormat.hs
+++ b/core/Test/Tasty/ConsoleFormat.hs
@@ -1,0 +1,24 @@
+module Test.Tasty.ConsoleFormat
+  ( ConsoleFormat(..)
+  , failFormat
+  , infoFailFormat
+  , infoOkFormat
+  , okFormat
+  , skippedFormat
+  )
+where
+
+import System.Console.ANSI
+
+data ConsoleFormat = ConsoleFormat
+  { consoleIntensity :: ConsoleIntensity
+  , colorIntensity   :: ColorIntensity
+  , color            :: Color
+  }
+
+failFormat, infoFailFormat, infoOkFormat, okFormat, skippedFormat :: ConsoleFormat
+failFormat     = ConsoleFormat BoldIntensity   Vivid Red
+infoFailFormat = ConsoleFormat NormalIntensity Dull  Red
+infoOkFormat   = ConsoleFormat NormalIntensity Dull  White
+okFormat       = ConsoleFormat NormalIntensity Dull  Green
+skippedFormat  = ConsoleFormat NormalIntensity Dull  Magenta

--- a/core/Test/Tasty/ConsoleFormat.hs
+++ b/core/Test/Tasty/ConsoleFormat.hs
@@ -1,5 +1,11 @@
+-- | Console output format
+--
+-- These console formats tasty uses when reporing.
+-- They are exported so custom providers with custom report printing
+-- can re-use the tasty output formats
 module Test.Tasty.ConsoleFormat
   ( ConsoleFormat(..)
+  , ConsoleFormatPrinter
   , failFormat
   , infoFailFormat
   , infoOkFormat
@@ -10,15 +16,35 @@ where
 
 import System.Console.ANSI
 
+-- | Console output format
 data ConsoleFormat = ConsoleFormat
   { consoleIntensity :: ConsoleIntensity
   , colorIntensity   :: ColorIntensity
   , color            :: Color
   }
 
-failFormat, infoFailFormat, infoOkFormat, okFormat, skippedFormat :: ConsoleFormat
-failFormat     = ConsoleFormat BoldIntensity   Vivid Red
+-- | Type of console format printer functions
+type ConsoleFormatPrinter
+  =  ConsoleFormat -- ^ selected console format
+  -> IO ()         -- ^ action to be executed with active console format
+  -> IO ()
+
+-- | Format used to display failures
+failFormat :: ConsoleFormat
+failFormat = ConsoleFormat BoldIntensity   Vivid Red
+
+-- | Format used to display additional information on failures
+infoFailFormat :: ConsoleFormat
 infoFailFormat = ConsoleFormat NormalIntensity Dull  Red
-infoOkFormat   = ConsoleFormat NormalIntensity Dull  White
-okFormat       = ConsoleFormat NormalIntensity Dull  Green
-skippedFormat  = ConsoleFormat NormalIntensity Dull  Magenta
+
+-- | Format used to display sucesses
+okFormat :: ConsoleFormat
+okFormat = ConsoleFormat NormalIntensity Dull  Green
+
+-- | Format used to display additional information on sucesses
+infoOkFormat :: ConsoleFormat
+infoOkFormat = ConsoleFormat NormalIntensity Dull  White
+
+-- | Format used to display skipped tests
+skippedFormat :: ConsoleFormat
+skippedFormat = ConsoleFormat NormalIntensity Dull  Magenta

--- a/core/Test/Tasty/Core.hs
+++ b/core/Test/Tasty/Core.hs
@@ -5,6 +5,7 @@
 module Test.Tasty.Core where
 
 import Control.Exception
+import Test.Tasty.ConsoleFormat
 import Test.Tasty.Options
 import Test.Tasty.Patterns
 import Test.Tasty.Patterns.Types
@@ -47,6 +48,14 @@ data Outcome
 -- | Time in seconds. Used to measure how long the tests took to run.
 type Time = Double
 
+newtype ResultDetailsPrinter = ResultDetailsPrinter ((ConsoleFormat -> IO () -> IO ()) -> IO ())
+
+noResultDetails :: ResultDetailsPrinter
+noResultDetails = ResultDetailsPrinter . const $ return ()
+
+instance Show ResultDetailsPrinter where
+  show _printer = "IO ResultDetailsPrinter"
+
 -- | A test result
 data Result = Result
   { resultOutcome :: Outcome
@@ -65,6 +74,11 @@ data Result = Result
     -- @FAIL@.
   , resultTime :: Time
     -- ^ How long it took to run the test, in seconds.
+  , resultDetailsPrinter :: ResultDetailsPrinter
+    -- ^ Optional detailed result printing action.
+    --
+    -- 'resultDetailsPrinter' is used by providers that need to have fine grained
+    -- control about the printed results. Especially when it comes to colorization.
   }
   deriving Show
 
@@ -104,6 +118,7 @@ exceptionResult e = Result
   , resultDescription = "Exception: " ++ show e
   , resultShortDescription = "FAIL"
   , resultTime = 0
+  , resultDetailsPrinter = noResultDetails
   }
 
 -- | Test progress information.

--- a/core/Test/Tasty/Core.hs
+++ b/core/Test/Tasty/Core.hs
@@ -48,10 +48,10 @@ data Outcome
 -- | Time in seconds. Used to measure how long the tests took to run.
 type Time = Double
 
-newtype ResultDetailsPrinter = ResultDetailsPrinter ((ConsoleFormat -> IO () -> IO ()) -> IO ())
+newtype ResultDetailsPrinter = ResultDetailsPrinter (Int -> (ConsoleFormat -> IO () -> IO ()) -> IO ())
 
 noResultDetails :: ResultDetailsPrinter
-noResultDetails = ResultDetailsPrinter . const $ return ()
+noResultDetails = ResultDetailsPrinter . const . const $ return ()
 
 instance Show ResultDetailsPrinter where
   show _printer = "IO ResultDetailsPrinter"

--- a/core/Test/Tasty/Core.hs
+++ b/core/Test/Tasty/Core.hs
@@ -48,8 +48,22 @@ data Outcome
 -- | Time in seconds. Used to measure how long the tests took to run.
 type Time = Double
 
-newtype ResultDetailsPrinter = ResultDetailsPrinter (Int -> (ConsoleFormat -> IO () -> IO ()) -> IO ())
+-- | Detailed result printer
+--
+-- Executed per 'Result' by the tasty reporter. Allow to customize result
+-- printing.
+type ResultDetailsPrinterFunction
+  =  Int                  -- ^ Current indentation level
+  -> ConsoleFormatPrinter -- ^ Format ware printer to be used by providers.
+  -> IO ()
 
+-- | Detailed result printer
+--
+-- Newtype wrapper around 'ResultDetailsPrinterFunction' to allow a
+-- custom Show instance.
+newtype ResultDetailsPrinter = ResultDetailsPrinter ResultDetailsPrinterFunction
+
+-- | Noop result details printer. The default for most providers.
 noResultDetails :: ResultDetailsPrinter
 noResultDetails = ResultDetailsPrinter . const . const $ return ()
 
@@ -69,16 +83,24 @@ data Result = Result
     --
     -- For a failed test, 'resultDescription' should typically provide more
     -- information about the failure.
+    --
+    -- The result description is printed with failure format in case of a test
+    -- failure and success format in case of test success.
+    --
+    -- If the provider author needs more fine grained control about the output
+    -- format feel free to provide an alternative 'resultDetailsPrinter'.
   , resultShortDescription :: String
     -- ^ The short description printed in the test run summary, usually @OK@ or
     -- @FAIL@.
   , resultTime :: Time
     -- ^ How long it took to run the test, in seconds.
   , resultDetailsPrinter :: ResultDetailsPrinter
-    -- ^ Optional detailed result printing action.
+    -- ^ Detailed result printer.
     --
-    -- 'resultDetailsPrinter' is used by providers that need to have fine grained
-    -- control about the printed results. Especially when it comes to colorization.
+    -- By default does nothing. See 'noResultDetails'.
+    --
+    -- Used by providers that need to have fine grained control about the printed
+    -- results via 'ResultDetailsPrinterFunction'.
   }
   deriving Show
 

--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -132,7 +132,7 @@ buildTestOutput opts tree =
             (if resultSuccessful result then infoOk else infoFail) $
               printf "%s%s\n" (indent $ level + 1) (formatDesc (level+1) rDesc)
           case resultDetailsPrinter result of
-            ResultDetailsPrinter action -> action withConsoleFormat
+            ResultDetailsPrinter action -> action level withConsoleFormat
 
       return $ PrintTest name printTestName printTestResult
 

--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -636,11 +636,14 @@ output
   -> IO ()
 output format = withConsoleFormat format . putStr
 
-withConsoleFormat
-  :: (?colors :: Bool)
-  => ConsoleFormat
-  -> IO ()
-  -> IO ()
+-- | Run action with console configured for a specific output format
+--
+-- This function does not apply any output formats if colors are disabled at command
+-- line or console detection.
+--
+-- Can be used by providers that wish to provider specific result details printing,
+-- while re-using the tasty formats and coloring logic.
+withConsoleFormat :: (?colors :: Bool) => ConsoleFormatPrinter
 withConsoleFormat format action
   | ?colors =
     (do

--- a/core/Test/Tasty/Providers.hs
+++ b/core/Test/Tasty/Providers.hs
@@ -1,8 +1,10 @@
 -- | API for test providers
 module Test.Tasty.Providers
   ( IsTest(..)
+  , ResultDetailsPrinter(..)
   , testPassed
   , testFailed
+  , testFailedDetails
   , Result
   , Progress(..)
   , TestName
@@ -26,6 +28,7 @@ testPassed desc = Result
   , resultDescription = desc
   , resultShortDescription = "OK"
   , resultTime = 0
+  , resultDetailsPrinter = noResultDetails
   }
 
 -- | 'Result' of a failed test
@@ -37,4 +40,13 @@ testFailed desc = Result
   , resultDescription = desc
   , resultShortDescription = "FAIL"
   , resultTime = 0
+  , resultDetailsPrinter = noResultDetails
   }
+
+-- | 'Result' of a failed test with custom details printer
+testFailedDetails
+  :: String               -- ^ description
+  -> ResultDetailsPrinter -- ^ details printer
+  -> Result
+testFailedDetails desc printer = (testFailed desc)
+  { resultDetailsPrinter = printer }

--- a/core/Test/Tasty/Run.hs
+++ b/core/Test/Tasty/Run.hs
@@ -157,6 +157,7 @@ executeTest action statusVar timeoutOpt inits fins = mask $ \restore -> do
                 "Timed out after " ++ tstr
             , resultShortDescription = "TIMEOUT"
             , resultTime = fromIntegral t
+            , resultDetailsPrinter = noResultDetails
             }
       fromMaybe timeoutResult <$> timeout t a
 
@@ -322,6 +323,7 @@ resolveDeps tests = checkCycles $ do
           , resultDescription = ""
           , resultShortDescription = "SKIP"
           , resultTime = 0
+          , resultDetailsPrinter = noResultDetails
           }
       }
   return ((action, statusVar), (path0, dep_paths))

--- a/core/tasty.cabal
+++ b/core/tasty.cabal
@@ -33,6 +33,7 @@ flag clock
 library
   exposed-modules:
     Test.Tasty,
+    Test.Tasty.ConsoleFormat,
     Test.Tasty.Options,
     Test.Tasty.Providers,
     Test.Tasty.Runners


### PR DESCRIPTION
### Motivation

I'm in the need for a golden test framework that renders a "pretty" (as with colors) unified diff output on expectation mismatches. And I made a test provider for this use case.

But: I think there is no way for the tasty console reporter to render such a report. Hence I took my stab to extend the tasty core with such an API.

### On the commits

* All but the last commits are cleanups "I like", I'm fine to drop all of them in need. Just let me know.
* The last commit is the feature addition.

### Notes on the last commit

* The `printResultDetails` function has a rather complex signature, this is because I wanted the provider I write to not re-do any console details discovery.
* I expect no changes to existing providers.
* I expect no runtime overhead for existing providers.
* I "currently" do not have an idea to make a less invasive API, and I'm very happy to get pointed to improvements.
* I also avoided to pass the current indentation to the detailed report, as I do not need it in my case.

I'm very happy to receive input on this PR and address any flags that come up.