### PR TITLE
Use value/showDefaultWith instead of manually displaying "default: <value>"

### DIFF
--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -458,8 +458,11 @@ instance IsOption UseColor where
   defaultValue = Auto
   parseValue = parseUseColor
   optionName = return "color"
-  optionHelp = return "When to use colored output (default: 'auto')"
-  optionCLParser = mkOptionCLParser $ metavar "never|always|auto"
+  optionHelp = return "When to use colored output"
+  optionCLParser = mkOptionCLParser $
+    metavar "never|always|auto" <>
+    value defaultValue <>
+    showDefaultWith displayUseColor
 
 -- | By default, when the option @--hide-successes@ is given and the output
 -- goes to an ANSI-capable terminal, we employ some ANSI terminal tricks to
@@ -475,7 +478,7 @@ instance IsOption UseColor where
 --
 -- When that happens, this option can be used to disable the tricks. In
 -- that case, the test name will be printed only once the test fails.
-newtype AnsiTricks = AnsiTricks Bool
+newtype AnsiTricks = AnsiTricks { getAnsiTricks :: Bool }
   deriving Typeable
 
 instance IsOption AnsiTricks where
@@ -485,7 +488,16 @@ instance IsOption AnsiTricks where
   optionHelp = return $
     -- Multiline literals don't work because of -XCPP.
     "Enable various ANSI terminal tricks. " ++
-    "Can be set to 'true' (default) or 'false'."
+    "Can be set to 'true' or 'false'."
+  optionCLParser = mkOptionCLParser $
+    value defaultValue <>
+    showDefaultWith (displayBool . getAnsiTricks)
+
+displayBool :: Bool -> String
+displayBool b =
+  case b of
+    False -> "false"
+    True  -> "true"
 
 -- | @useColor when isTerm@ decides if colors should be used,
 --   where @isTerm@ indicates whether @stdout@ is a terminal device.
@@ -505,6 +517,13 @@ parseUseColor s =
     "always" -> return Always
     "auto"   -> return Auto
     _        -> Nothing
+
+displayUseColor :: UseColor -> String
+displayUseColor uc =
+  case uc of
+    Never  -> "never"
+    Always -> "always"
+    Auto   -> "auto"
 
 -- }}}
 

--- a/core/Test/Tasty/Options/Core.hs
+++ b/core/Test/Tasty/Options/Core.hs
@@ -35,8 +35,12 @@ instance IsOption NumThreads where
   defaultValue = NumThreads numCapabilities
   parseValue = mfilter onlyPositive . fmap NumThreads . safeRead
   optionName = return "num-threads"
-  optionHelp = return "Number of threads to use for tests execution (default: # of cores/capabilities)"
-  optionCLParser = mkOptionCLParser (short 'j' <> metavar "NUMBER")
+  optionHelp = return "Number of threads to use for tests execution"
+  optionCLParser = mkOptionCLParser $
+    short 'j' <>
+    metavar "NUMBER" <>
+    value defaultValue <>
+    showDefaultWith (\_ -> "# of cores/capabilities")
 
 -- | Filtering function to prevent non-positive number of threads
 onlyPositive :: NumThreads -> Bool


### PR DESCRIPTION
This follows up on https://github.com/feuerbach/tasty-golden/pull/33#issuecomment-596046594 by using `optparse-applicative`'s `value` and `showDefaultWith` combinators to display default values in `--help` output instead of hard-wiring the phrase `default: <value>` into the help description.