### PR TITLE
Do not install handlers for SIGSEGV & Co

### DIFF
--- a/core/Test/Tasty/Runners/Utils.hs
+++ b/core/Test/Tasty/Runners/Utils.hs
@@ -67,8 +67,7 @@ installSignalHandlers = do
 #if INSTALL_HANDLERS
   main_thread_id <- myThreadId
   weak_tid <- mkWeakThreadId main_thread_id
-  forM_ [ sigABRT, sigBUS, sigFPE, sigHUP, sigILL, sigQUIT, sigSEGV,
-          sigSYS, sigTERM, sigUSR1, sigUSR2, sigXCPU, sigXFSZ ] $ \sig ->
+  forM_ [ sigHUP, sigTERM, sigUSR1, sigUSR2, sigXCPU, sigXFSZ ] $ \sig ->
     installHandler sig (Catch $ send_exception weak_tid sig) Nothing
   where
     send_exception weak_tid sig = do


### PR DESCRIPTION
Namely signals that normally result in immediate program termination and core
dump: SIGABRT, SIGBUS, SIGFPE, SIGILL, SIGQUIT, SIGSEGV, SIGSYS.

If program receives any of these signals it means that something at some point
went extremely wrong and only hope to debug it is to dump core and to poke
around with gdb. Converting to exception takes core away.

In addition makes memory corruption bugs to look like something else:

> Segmentaiton fault (core dumped)

Line above is familiar and very alarming sight. `SignalException 11` doen;t have
same punch. As bonus point memory corruption may lead to exception loop when
when handling SIGSEGV you get another one, etc. It fact it did happen and was
very puzzling.

By default SIGXCPU, SIGXFSZ result in core but they left in the list since they
aren't coused by some problem in program.