### PR TITLE
Add OptionSet to fields in TreeFold

### DIFF
--- a/core-tests/test.hs
+++ b/core-tests/test.hs
@@ -61,7 +61,7 @@ getTestNames =
   foldTestTree
     trivialFold
       { foldSingle = \_ name _ -> [name]
-      , foldGroup = \n l -> map ((n ++ ".") ++) l
+      , foldGroup = \_opts n l -> map ((n ++ ".") ++) l
       }
 
 -- the tree being tested

--- a/core/Test/Tasty/Core.hs
+++ b/core/Test/Tasty/Core.hs
@@ -1,6 +1,6 @@
 -- | Core types and definitions
 {-# LANGUAGE GeneralizedNewtypeDeriving, FlexibleContexts,
-             ExistentialQuantification, RankNTypes, DeriveDataTypeable,
+             ExistentialQuantification, RankNTypes, DeriveDataTypeable, NoMonomorphismRestriction,
              DeriveGeneric #-}
 module Test.Tasty.Core where
 
@@ -310,9 +310,9 @@ after deptype s =
 -- indroduced.
 data TreeFold b = TreeFold
   { foldSingle :: forall t . IsTest t => OptionSet -> TestName -> t -> b
-  , foldGroup :: TestName -> b -> b
-  , foldResource :: forall a . ResourceSpec a -> (IO a -> b) -> b
-  , foldAfter :: DependencyType -> Expr -> b -> b
+  , foldGroup :: OptionSet -> TestName -> b -> b
+  , foldResource :: forall a . OptionSet -> ResourceSpec a -> (IO a -> b) -> b
+  , foldAfter :: OptionSet -> DependencyType -> Expr -> b -> b
   }
 
 -- | 'trivialFold' can serve as the basis for custom folds. Just override
@@ -329,9 +329,9 @@ data TreeFold b = TreeFold
 trivialFold :: Monoid b => TreeFold b
 trivialFold = TreeFold
   { foldSingle = \_ _ _ -> mempty
-  , foldGroup = const id
-  , foldResource = \_ f -> f $ throwIO NotRunningTests
-  , foldAfter = \_ _ b -> b
+  , foldGroup = \_ _ b -> b
+  , foldResource = \_ _ f -> f $ throwIO NotRunningTests
+  , foldAfter = \_ _ _ b -> b
   }
 
 -- | Fold a test tree into a single value.
@@ -353,7 +353,7 @@ trivialFold = TreeFold
 -- affected by the subsequent option changes. This shouldn't be a problem
 -- in practice; OTOH, this behaviour may be changed later.
 foldTestTree
-  :: Monoid b
+  :: forall b . Monoid b
   => TreeFold b
      -- ^ the algebra (i.e. how to fold a tree)
   -> OptionSet
@@ -365,6 +365,8 @@ foldTestTree (TreeFold fTest fGroup fResource fAfter) opts0 tree0 =
   let pat = lookupOption opts0
   in go pat mempty opts0 tree0
   where
+    go :: (TestPattern
+                  -> Seq.Seq TestName -> OptionSet -> TestTree -> b)
     go pat path opts tree1 =
       case tree1 of
         SingleTest name test
@@ -372,11 +374,11 @@ foldTestTree (TreeFold fTest fGroup fResource fAfter) opts0 tree0 =
             -> fTest opts name test
           | otherwise -> mempty
         TestGroup name trees ->
-          fGroup name $ foldMap (go pat (path Seq.|> name) opts) trees
+          fGroup opts name $ foldMap (go pat (path Seq.|> name) opts) trees
         PlusTestOptions f tree -> go pat path (f opts) tree
-        WithResource res0 tree -> fResource res0 $ \res -> go pat path opts (tree res)
+        WithResource res0 tree -> fResource opts res0 $ \res -> go pat path opts (tree res)
         AskOptions f -> go pat path opts (f opts)
-        After deptype dep tree -> fAfter deptype dep $ go pat path opts tree
+        After deptype dep tree -> fAfter opts deptype dep $ go pat path opts tree
 
 -- | Get the list of options that are relevant for a given test tree
 treeOptions :: TestTree -> [OptionDescription]

--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -136,8 +136,8 @@ buildTestOutput opts tree =
 
       return $ PrintTest name printTestName printTestResult
 
-    runGroup :: TestName -> Ap (Reader Level) TestOutput -> Ap (Reader Level) TestOutput
-    runGroup name grp = Ap $ do
+    runGroup :: OptionSet -> TestName -> Ap (Reader Level) TestOutput -> Ap (Reader Level) TestOutput
+    runGroup _opts name grp = Ap $ do
       level <- ask
       let
         printHeading = printf "%s%s\n" (indent level) name
@@ -595,7 +595,7 @@ computeAlignment opts =
   foldTestTree
     trivialFold
       { foldSingle = \_ name _ level -> Maximum (stringWidth name + level)
-      , foldGroup = \_ m -> m . (+ indentSize)
+      , foldGroup = \_opts _ m -> m . (+ indentSize)
       }
     opts
   where

--- a/core/Test/Tasty/Ingredients/ListTests.hs
+++ b/core/Test/Tasty/Ingredients/ListTests.hs
@@ -31,7 +31,7 @@ testsNames {- opts -} {- tree -} =
   foldTestTree
     trivialFold
       { foldSingle = \_opts name _test -> [name]
-      , foldGroup = \groupName names -> map ((groupName ++ ".") ++) names
+      , foldGroup = \_opts groupName names -> map ((groupName ++ ".") ++) names
       }
 
 -- | The ingredient that provides the test listing functionality

--- a/core/Test/Tasty/Run.hs
+++ b/core/Test/Tasty/Run.hs
@@ -233,9 +233,9 @@ createTestActions opts0 tree = do
         (trivialFold :: TreeFold Tr)
           { foldSingle = runSingleTest
           , foldResource = addInitAndRelease
-          , foldGroup = \name (Traversal a) ->
+          , foldGroup = \_opts name (Traversal a) ->
               Traversal $ local (first (Seq.|> name)) a
-          , foldAfter = \deptype pat (Traversal a) ->
+          , foldAfter = \_opts deptype pat (Traversal a) ->
               Traversal $ local (second ((deptype, pat) :)) a
           }
         opts0 tree
@@ -260,8 +260,8 @@ createTestActions opts0 tree = do
         act (inits, fins) =
           executeTest (run opts test) statusVar (lookupOption opts) inits fins
       tell ([(act, (statusVar, path, deps))], mempty)
-    addInitAndRelease :: ResourceSpec a -> (IO a -> Tr) -> Tr
-    addInitAndRelease (ResourceSpec doInit doRelease) a = wrap $ \path deps -> do
+    addInitAndRelease :: OptionSet -> ResourceSpec a -> (IO a -> Tr) -> Tr
+    addInitAndRelease _opts (ResourceSpec doInit doRelease) a = wrap $ \path deps -> do
       initVar <- atomically $ newTVar NotCreated
       (tests, fins) <- unwrap path deps $ a (getResource initVar)
       let ntests = length tests


### PR DESCRIPTION
Breaking Change, changes field signatures in TreeFold.
Helpful for writing custom test-runners.

closes #276 