### PR TITLE
Allow `TestPattern` to be modified inside a `TestTree`

### DIFF
--- a/core-tests/test.hs
+++ b/core-tests/test.hs
@@ -51,6 +51,12 @@ patternTests = testGroup "Patterns"
       (o "ca.Ot" @?= ["Tests.North America.Ottawa"])
   , testCase ". is a field separator (works inside an AWK expression)" $
       (o "/ca.Ot/" @?= ["Tests.North America.Ottawa"])
+  , testCase "Trees can adjust pattern" $
+      let tt' =
+            adjustOption (\(TestPattern _) -> fromJust $ parseTestPattern "Paris")
+              tt
+      in
+        (getTestNames mempty tt' @?= ["Tests.Europe.Paris"])
   ]
   where
   -- apply a pattern to tt and get the names of tests that match

--- a/core/Test/Tasty/Core.hs
+++ b/core/Test/Tasty/Core.hs
@@ -362,23 +362,23 @@ foldTestTree
      -- ^ the tree to fold
   -> b
 foldTestTree (TreeFold fTest fGroup fResource fAfter) opts0 tree0 =
-  let pat = lookupOption opts0
-  in go pat mempty opts0 tree0
+  go mempty opts0 tree0
   where
-    go :: (TestPattern
-                  -> Seq.Seq TestName -> OptionSet -> TestTree -> b)
-    go pat path opts tree1 =
+    go :: (Seq.Seq TestName -> OptionSet -> TestTree -> b)
+    go path opts tree1 =
       case tree1 of
         SingleTest name test
           | testPatternMatches pat (path Seq.|> name)
             -> fTest opts name test
           | otherwise -> mempty
         TestGroup name trees ->
-          fGroup opts name $ foldMap (go pat (path Seq.|> name) opts) trees
-        PlusTestOptions f tree -> go pat path (f opts) tree
-        WithResource res0 tree -> fResource opts res0 $ \res -> go pat path opts (tree res)
-        AskOptions f -> go pat path opts (f opts)
-        After deptype dep tree -> fAfter opts deptype dep $ go pat path opts tree
+          fGroup opts name $ foldMap (go (path Seq.|> name) opts) trees
+        PlusTestOptions f tree -> go path (f opts) tree
+        WithResource res0 tree -> fResource opts res0 $ \res -> go path opts (tree res)
+        AskOptions f -> go path opts (f opts)
+        After deptype dep tree -> fAfter opts deptype dep $ go path opts tree
+      where
+        pat = lookupOption opts :: TestPattern
 
 -- | Get the list of options that are relevant for a given test tree
 treeOptions :: TestTree -> [OptionDescription]


### PR DESCRIPTION
I ran into a scenario where I needed to modify the `TestPattern` option programmatically.

It seems Tasty does not support this, because `foldTestTree` reads the pattern once at the start, before traversing the tree, and then never reads it again.

This PR changes `foldTestTree` to read the pattern option each time it goes down a level.