### PR TITLE
Add flag unix

### DIFF
--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -41,7 +41,7 @@ import Test.Tasty.Runners.Utils
 import Text.Printf
 import qualified Data.IntMap as IntMap
 import Data.Char
-#ifdef UNIX
+#ifdef VERSION_wcwidth
 import Data.Char.WCWidth (wcwidth)
 #endif
 import Data.Maybe
@@ -612,7 +612,7 @@ computeAlignment opts =
 --   (This only works properly on Unix at the moment; on Windows, the function
 --   treats every character as width-1 like 'Data.List.length' does.)
 stringWidth :: String -> Int
-#ifdef UNIX
+#ifdef VERSION_wcwidth
 stringWidth = Prelude.sum . map charWidth
  where charWidth c = case wcwidth c of
         -1 -> 1  -- many chars have "undefined" width; default to 1 for these.

--- a/core/Test/Tasty/Runners/Utils.hs
+++ b/core/Test/Tasty/Runners/Utils.hs
@@ -19,7 +19,7 @@ import qualified System.Clock as Clock
 #endif
 
 -- Install handlers only on UNIX
-#define INSTALL_HANDLERS defined __UNIX__
+#define INSTALL_HANDLERS defined VERSION_unix
 
 #if INSTALL_HANDLERS
 import System.Posix.Signals

--- a/core/tasty.cabal
+++ b/core/tasty.cabal
@@ -30,6 +30,11 @@ flag clock
     Depend on the clock package for more accurate time measurement
   default: True
 
+flag unix
+  description:
+    Depend on the unix package to install signal handlers
+  default: True
+
 library
   exposed-modules:
     Test.Tasty,
@@ -77,9 +82,9 @@ library
     build-depends: time >= 1.4
 
   if !os(windows) && !impl(ghcjs)
-    build-depends: unix,
-                   wcwidth
-    cpp-options: -D__UNIX__
+    build-depends: wcwidth
+    if flag(unix)
+      build-depends: unix
 
   -- hs-source-dirs:
   default-language:    Haskell2010


### PR DESCRIPTION
This allows to use `tasty` as a test framework for `unix` and `bytestring`, avoiding circlular dependencies.