### PR TITLE
Avoid macro expansion producing 'defined'

### DIFF
--- a/core/Test/Tasty/Runners/Utils.hs
+++ b/core/Test/Tasty/Runners/Utils.hs
@@ -19,7 +19,11 @@ import qualified System.Clock as Clock
 #endif
 
 -- Install handlers only on UNIX
-#define INSTALL_HANDLERS defined VERSION_unix
+#ifdef VERSION_unix
+#define INSTALL_HANDLERS 1
+#else
+#define INSTALL_HANDLERS 0
+#endif
 
 #if INSTALL_HANDLERS
 import System.Posix.Signals


### PR DESCRIPTION
Recent version of Clang warns this having undefined behavior (by `-Wexpansion-to-defined`), and it causes compilation error if `-Werror` is specified.

I encountered the problem on Apple clang version 12.0.0 (clang-1200.0.32.27) on macOS Catalina (10.15.7).

https://travis-ci.org/github/msakai/tasty/builds/753659349

```
configure (lib)
Configuring tasty-1.4.0.2...
build (lib)
Preprocessing library for tasty-1.4.0.2..
Building library for tasty-1.4.0.2..

/Users/travis/build/msakai/tasty/core/Test/Tasty/Runners/Utils.hs:24:5: error:
     error: macro expansion producing 'defined' has undefined behavior [-Werror,-Wexpansion-to-defined]
   |
24 | #if INSTALL_HANDLERS
   |     ^
#if INSTALL_HANDLERS
    ^

/Users/travis/build/msakai/tasty/core/Test/Tasty/Runners/Utils.hs:22:26: error:
     note: expanded from macro 'INSTALL_HANDLERS'
   |
22 | #define INSTALL_HANDLERS defined VERSION_unix
   |                          ^
#define INSTALL_HANDLERS defined VERSION_unix
                         ^

/Users/travis/build/msakai/tasty/core/Test/Tasty/Runners/Utils.hs:68:5: error:
     error: macro expansion producing 'defined' has undefined behavior [-Werror,-Wexpansion-to-defined]
   |
68 | #if INSTALL_HANDLERS
   |     ^
#if INSTALL_HANDLERS
    ^

/Users/travis/build/msakai/tasty/core/Test/Tasty/Runners/Utils.hs:22:26: error:
     note: expanded from macro 'INSTALL_HANDLERS'
   |
22 | #define INSTALL_HANDLERS defined VERSION_unix
   |                          ^
#define INSTALL_HANDLERS defined VERSION_unix
                         ^
2 errors generated.

/Users/travis/build/msakai/tasty/core/Test/Tasty/Runners/Utils.hs:1:1: error:
    `gcc' failed in phase `C pre-processor'. (Exit code: 1)
  |
1 | {-# LANGUAGE BangPatterns #-}
  | ^
```
